### PR TITLE
Small fixups for second pod example

### DIFF
--- a/lib/HTTP/Tiny/Multipart.pm
+++ b/lib/HTTP/Tiny/Multipart.pm
@@ -165,7 +165,8 @@ And
             filename => 'test.txt',
             content  => $content,
             content_type  => 'text/plain',
-        }
+        },
+        testfield => 'test'
     } );
 
 creates
@@ -182,7 +183,7 @@ creates
   Content-Type: text/plain
   
   This is a test
-  --go7DX--
+  --go7DX
   Content-Disposition: form-data; name="testfield"
   
   test


### PR DESCRIPTION
1. There's a name="testfield" section in the output, but no testfield
   in the corresponding request.

2. Looks like there was a cut & paste error on the second boundary.