### PR TITLE
Fix a bug in _get_boundary when $1 is defined.

### DIFF
--- a/lib/HTTP/Tiny/Multipart.pm
+++ b/lib/HTTP/Tiny/Multipart.pm
@@ -26,10 +26,14 @@ sub _get_boundary {
     }
  
     # Add boundary to Content-Type header
-    ($headers->{'content-type'} || '') =~ m!^(.*multipart/[^;]+)(.*)$!;
-
-    my $before = $1 || 'multipart/form-data';
-    my $after  = $2 || '';
+    my $before = 'multipart/form-data';
+    my $after  = '';
+    if(exists($$headers{'content-type'})) {
+        if($$headers{'content-type'} =~ m!^(.*multipart/[^;]+)(.*)$!) {
+            $before = $1;
+            $after  = $2;
+        }
+    }
 
     $headers->{'content-type'} = "$before; boundary=$boundary$after";
  


### PR DESCRIPTION
If $1 is defined, the Content-Type of the request is incorrect.  The
fix is to only use $1 and $2 if the regex matched.