### PR TITLE
Some small cleanups to things I noticed.

### DIFF
--- a/lib/HTTP/Tiny/Multipart.pm
+++ b/lib/HTTP/Tiny/Multipart.pm
@@ -93,6 +93,8 @@ no warnings 'redefine';
 *HTTP::Tiny::post_multipart = sub {
     my ($self, $url, $data, $args) = @_;
 
+    local $Carp::Internal{ 'HTTP::Tiny::Multipart' } = 1;
+
     (@_ == 3 || @_ == 4 && ref $args eq 'HASH')
         or Carp::croak(q/Usage: $http->post_multipart(URL, DATAREF, [HASHREF])/ . "\n");
 
@@ -104,8 +106,6 @@ no warnings 'redefine';
         $headers->{lc $key} = $value;
     }
 
-    delete $args->{headers};
-
     my $content_parts = _build_content($data);
     my $boundary      = _get_boundary($headers, $content_parts);
 
@@ -115,9 +115,7 @@ no warnings 'redefine';
     return $self->request('POST', $url, {
             %$args,
             content => $boundary . join( $boundary, @{$content_parts}) . $last_boundary,
-            headers => {
-                %$headers,
-            },
+            headers => $headers,
         }
     );
 };


### PR DESCRIPTION
- Do not modify the args hash, it is a user supplied reference, and removing headers from it is a noop since the headers key is already defined after the args when calling request().
- No need to double clone the headers hash.
- Update Carp::Internal so that croak()s actually end up at a useful place.